### PR TITLE
sort language and fix settings preview

### DIFF
--- a/A2N Hymnal/SettingsView.swift
+++ b/A2N Hymnal/SettingsView.swift
@@ -40,7 +40,7 @@ struct SettingsView : View {
                     ) {
                         Divider().padding(.vertical, 4)
                         Picker("Language", selection: settings.$hymnLocale) {
-                            ForEach(Array(locales.keys), id: \.self) {
+                            ForEach(Array(locales.keys.sorted(by: { locales[$0]!.name < locales[$1]!.name })), id: \.self) {
                                 Text(locales[$0]!.name)
                             }
                         }
@@ -116,5 +116,6 @@ func getAppInfo(key: String) -> String? {
 }
 
 #Preview {
-    SettingsView()
+SettingsView()
+    .environmentObject(Settings())
 }


### PR DESCRIPTION
languages now appear in alphabetical order
![image](https://github.com/paulchen95/gphymnal/assets/4129217/2bc89a2a-4069-4a1c-a458-d64626056ef5)

also fix xcode preview for SettingsView 